### PR TITLE
Update to prefer STRING if one is found in the column

### DIFF
--- a/lib/guess-model.js
+++ b/lib/guess-model.js
@@ -138,6 +138,10 @@ function dataToType(data, name, tablesOptions = {}) {
   else if (_.size(counted) === 1) {
     kind = top.kind;
   }
+  // If there is a string, use strin
+  else if (counted.STRING) {
+    kind = 'STRING';
+  }
   // If there is an integer and a float, use float
   else if (counted.INTGER && counted.FLOAT) {
     kind = 'FLOAT';


### PR DESCRIPTION
If there is even one recognized string in a column, then STRING should be inferred the column. 
Lets say you have a database with car plates numbers where numbers and characters are allowed with the following content:

> 123123
> 321321
> C1233A 

Even though integers only plate are a majority, the string should be picked.