### PR TITLE
Add option for overwriting guesses with known string columns

### DIFF
--- a/bin/tables.js
+++ b/bin/tables.js
@@ -70,6 +70,11 @@ command.option(
                                   comma-delimited list of columns such as "key|column_1" or ".*key|.*id".`
 );
 command.option(
+  '-s, --string-columns [name]',
+  `A comma-delimited list of columns that would be treated as string instead of guessed.
+                                  Only the length of the string would be guessed.`
+);
+command.option(
   '-t, --transformer [file]',
   `Reference to JS file that exports a function to transform data
                                   guessing model if models not provided, as we well as before db
@@ -150,6 +155,9 @@ async function cli() {
     key: command.key
       ? _.map(command.key.split(','), d => _.snakeCase(d.trim()))
       : undefined,
+    stringColumns: command.stringColumns
+      ? _.map(command.stringColumns.split(','), d => _.snakeCase(d.trim()))
+      : [],
     id: command.id ? command.id : undefined,
     fieldsToIndex:
       command.indexFields && command.indexFields.match(/^\//)
@@ -170,7 +178,7 @@ async function cli() {
     transformer: command.transformer ? command.transformer : undefined,
     models: command.models ? command.models : undefined
   };
-
+  
   // Input type specific options
   if (command.jsonPath) {
     options.format = 'json';

--- a/lib/guess-model.js
+++ b/lib/guess-model.js
@@ -129,9 +129,12 @@ function dataToType(data, name, tablesOptions = {}) {
   let maxLength = _.maxBy(data, d => (d && d.length ? d.length : 0));
   maxLength = maxLength ? maxLength.length : maxLength;
   let kind;
-
+  // If string is passed as option we just use that
+  if (tablesOptions.stringColumns.indexOf(_.snakeCase(name)) != -1) {
+    kind = 'STRING';
+  }
   // If none, then just assume string
-  if (_.size(data) === 0) {
+  else if (_.size(data) === 0) {
     return Sequelize.STRING;
   }
   // If there is only one kind, stick with that


### PR DESCRIPTION
There may be hundreds of files to import where certain columns with specific name are known to be intergers, however not guessed correctly from the sample data each time. 
So an option for overwriting column guesses to strings would be useful. 