### PR TITLE
Do not index TEXT

### DIFF
--- a/lib/guess-model.js
+++ b/lib/guess-model.js
@@ -68,7 +68,7 @@ function guessModel(data, tablesOptions = {}, sequlizeInstance) {
     fields[fieldName] = field;
 
     // Make indexes based on column name
-    if (shouldIndex(columnName, tablesOptions)) {
+    if (shouldIndex(columnName, tablesOptions) && field.type != 'TEXT') {
       // Index needs to use SQL name, not Sequelize name
       modelOptions.indexes.push({ fields: [sqlName] });
     }


### PR DESCRIPTION
In mysql if you try to index TEXT without specifing length of the index you would get an error "SequelizeDatabaseError: BLOB/TEXT column '?????' used in key specification without a key length"
So it is bettor to not index TEXT fields