### PR TITLE
Fix naming scheme for indexes to avoid conflicts

### DIFF
--- a/lib/guess-model.js
+++ b/lib/guess-model.js
@@ -70,7 +70,8 @@ function guessModel(data, tablesOptions = {}, sequlizeInstance) {
     // Make indexes based on column name
     if (shouldIndex(columnName, tablesOptions)) {
       // Index needs to use SQL name, not Sequelize name
-      modelOptions.indexes.push({ fields: [sqlName] });
+      // By default index name will be [table]_[fields]
+      modelOptions.indexes.push({ name: `ix_${sqlName}`, fields: [sqlName] });
     }
   });
 
@@ -142,8 +143,11 @@ function dataToType(data, name, tablesOptions = {}) {
   else if (_.size(counted) === 1) {
     kind = top.kind;
   }
+  else if (counted.STRING) {
+    kind = 'STRING';
+  }
   // If there is an integer and a float, use float
-  else if (counted.INTGER && counted.FLOAT) {
+  else if (counted.INTEGER && counted.FLOAT) {
     kind = 'FLOAT';
   }
   else {


### PR DESCRIPTION
Avoids naming conflicts for indexes when importing certain column names using mariadb (e.g., reserved words).

Also, included are fixes for longstanding bugs:
- Prefer STRING if one is found in the column (see: https://github.com/zzolo/tables/pull/4/files)
- Fix misspelled counted key for INTEGER (see: https://github.com/zzolo/tables/pull/3/files)


